### PR TITLE
Fix redirects with authRequest/Success/Error action.

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -11,10 +11,26 @@ export const setAuthToken = authToken => ({
     authToken
 });
 
-export const SET_CURRENT_USER = 'SET_CURRENT_USER';
-export const setCurrentUser = currentUser => ({
-    type: SET_CURRENT_USER,
+export const CLEAR_AUTH = 'CLEAR_AUTH';
+export const clearAuth = () => ({
+    type: CLEAR_AUTH
+});
+
+export const AUTH_REQUEST = 'AUTH_REQUEST';
+export const authRequest = () => ({
+    type: AUTH_REQUEST
+});
+
+export const AUTH_SUCCESS = 'AUTH_SUCCESS';
+export const authSuccess = currentUser => ({
+    type: AUTH_SUCCESS,
     currentUser
+});
+
+export const AUTH_ERROR = 'AUTH_ERROR';
+export const authError = error => ({
+    type: AUTH_ERROR,
+    error
 });
 
 // Stores the auth token in state and localStorage, and decodes and stores
@@ -22,11 +38,12 @@ export const setCurrentUser = currentUser => ({
 const storeAuthInfo = (authToken, dispatch) => {
     const decodedToken = jwtDecode(authToken);
     dispatch(setAuthToken(authToken));
-    dispatch(setCurrentUser(decodedToken.user));
+    dispatch(authSuccess(decodedToken.user));
     saveAuthToken(authToken);
 };
 
 export const login = (username, password) => dispatch => {
+    dispatch(authRequest());
     return (
         fetch(`${API_BASE_URL}/auth/login`, {
             method: 'POST',
@@ -45,20 +62,24 @@ export const login = (username, password) => dispatch => {
             .then(({authToken}) => storeAuthInfo(authToken, dispatch))
             .catch(err => {
                 const {code} = err;
-                if (code === 401) {
-                    // Could not authenticate, so return a SubmissionError for Redux
-                    // Form
-                    return Promise.reject(
-                        new SubmissionError({
-                            _error: 'Incorrect username or password'
-                        })
-                    );
-                }
+                const message =
+                    code === 401
+                        ? 'Incorrect username or password'
+                        : 'Unable to login, please try again';
+                dispatch(authError(err));
+                // Could not authenticate, so return a SubmissionError for Redux
+                // Form
+                return Promise.reject(
+                    new SubmissionError({
+                        _error: message
+                    })
+                );
             })
     );
 };
 
 export const refreshAuthToken = () => (dispatch, getState) => {
+    dispatch(authRequest());
     const authToken = getState().auth.authToken;
     return fetch(`${API_BASE_URL}/auth/refresh`, {
         method: 'POST',
@@ -71,13 +92,11 @@ export const refreshAuthToken = () => (dispatch, getState) => {
         .then(res => res.json())
         .then(({authToken}) => storeAuthInfo(authToken, dispatch))
         .catch(err => {
-            const {code} = err;
-            if (code === 401) {
-                // We couldn't get a refresh token because our current credentials
-                // are invalid or expired, so clear them and sign us out
-                dispatch(setCurrentUser(null));
-                dispatch(setAuthToken(null));
-                clearAuthToken(authToken);
-            }
+            // We couldn't get a refresh token because our current credentials
+            // are invalid or expired, or something else went wrong, so clear
+            // them and sign us out
+            dispatch(authError(err));
+            dispatch(clearAuth());
+            clearAuthToken(authToken);
         });
 };

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -9,14 +9,6 @@ import RegistrationPage from './registration-page';
 import {refreshAuthToken} from '../actions/auth';
 
 export class App extends React.Component {
-    componentDidMount() {
-        if (this.props.hasAuthToken) {
-            // Try to get a fresh auth token if we had an existing one in
-            // localStorage
-            this.props.dispatch(refreshAuthToken());
-        }
-    }
-
     componentWillReceiveProps(nextProps) {
         if (nextProps.loggedIn && !this.props.loggedIn) {
             // When we are logged in, refresh the auth token periodically

--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -1,22 +1,14 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {Redirect} from 'react-router-dom';
+import requiresLogin from './requires-login';
 import {fetchProtectedData} from '../actions/protected-data';
 
 export class Dashboard extends React.Component {
     componentDidMount() {
-        if (!this.props.loggedIn) {
-            return;
-        }
         this.props.dispatch(fetchProtectedData());
     }
 
     render() {
-        // Only visible to logged in users
-        if (!this.props.loggedIn) {
-            return <Redirect to="/" />;
-        }
-
         return (
             <div className="dashboard">
                 <div className="dashboard-username">
@@ -34,13 +26,10 @@ export class Dashboard extends React.Component {
 const mapStateToProps = state => {
     const {currentUser} = state.auth;
     return {
-        loggedIn: currentUser !== null,
-        username: currentUser ? state.auth.currentUser.username : '',
-        name: currentUser
-            ? `${currentUser.firstName} ${currentUser.lastName}`
-            : '',
+        username: state.auth.currentUser.username,
+        name: `${currentUser.firstName} ${currentUser.lastName}`,
         protectedData: state.protectedData.data
     };
 };
 
-export default connect(mapStateToProps)(Dashboard);
+export default requiresLogin()(connect(mapStateToProps)(Dashboard));

--- a/src/components/header-bar.js
+++ b/src/components/header-bar.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {setCurrentUser, setAuthToken} from '../actions/auth';
+import {clearAuth} from '../actions/auth';
 import {clearAuthToken} from '../local-storage';
 
 export class HeaderBar extends React.Component {
     logOut() {
-        this.props.dispatch(setCurrentUser(null));
-        this.props.dispatch(setAuthToken(null));
+        this.props.dispatch(clearAuth());
         clearAuthToken();
     }
 

--- a/src/components/requires-login.js
+++ b/src/components/requires-login.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import {Redirect} from 'react-router-dom';
+
+export default () => Component => {
+    function RequiresLogin(props) {
+        const {authenticating, loggedIn, error, ...passThroughProps} = props;
+        if (authenticating) {
+            return <div>Logging in...</div>;
+        } else if (!loggedIn || error) {
+            return <Redirect to="/" />;
+        }
+
+        return <Component {...passThroughProps} />;
+    }
+
+    const displayName = Component.displayName || Component.name || 'Component';
+    RequiresLogin.displayName = `requiresLogin(${displayName})`;
+
+    const mapStateToProps = (state, props) => ({
+        authenticating: state.auth.loading,
+        loggedIn: state.auth.currentUser !== null,
+        error: state.auth.error
+    });
+
+    return connect(mapStateToProps)(RequiresLogin);
+};

--- a/src/components/requires-login.js
+++ b/src/components/requires-login.js
@@ -15,7 +15,7 @@ export default () => Component => {
     }
 
     const displayName = Component.displayName || Component.name || 'Component';
-    RequiresLogin.displayName = `requiresLogin(${displayName})`;
+    RequiresLogin.displayName = `RequiresLogin(${displayName})`;
 
     const mapStateToProps = (state, props) => ({
         authenticating: state.auth.loading,

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,8 +1,16 @@
-import {SET_AUTH_TOKEN, SET_CURRENT_USER} from '../actions/auth';
+import {
+    SET_AUTH_TOKEN,
+    CLEAR_AUTH,
+    AUTH_REQUEST,
+    AUTH_SUCCESS,
+    AUTH_ERROR
+} from '../actions/auth';
 
 const initialState = {
     authToken: null, // authToken !== null does not mean it has been validated
-    currentUser: null
+    currentUser: null,
+    loading: false,
+    error: null
 };
 
 export default function reducer(state = initialState, action) {
@@ -10,9 +18,25 @@ export default function reducer(state = initialState, action) {
         return Object.assign({}, state, {
             authToken: action.authToken
         });
-    } else if (action.type === SET_CURRENT_USER) {
+    } else if (action.type === CLEAR_AUTH) {
         return Object.assign({}, state, {
+            authToken: null,
+            currentUser: null
+        });
+    } else if (action.type === AUTH_REQUEST) {
+        return Object.assign({}, state, {
+            loading: true,
+            error: null
+        });
+    } else if (action.type === AUTH_SUCCESS) {
+        return Object.assign({}, state, {
+            loading: false,
             currentUser: action.currentUser
+        });
+    } else if (action.type === AUTH_ERROR) {
+        return Object.assign({}, state, {
+            loading: false,
+            error: action.error
         });
     }
     return state;

--- a/src/store.js
+++ b/src/store.js
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import {loadAuthToken} from './local-storage';
 import authReducer from './reducers/auth';
 import protectedDataReducer from './reducers/protected-data';
-import {setAuthToken} from './actions/auth';
+import {setAuthToken, refreshAuthToken} from './actions/auth';
 
 const store = createStore(
     combineReducers({
@@ -20,6 +20,7 @@ const authToken = loadAuthToken();
 if (authToken) {
     const token = authToken;
     store.dispatch(setAuthToken(token));
+    store.dispatch(refreshAuthToken());
 }
 
 export default store;


### PR DESCRIPTION
Before this, refreshing the auth token would redirect to /dashboard,
even if the initial URL requested was /something-else.

Fixed by introducing the three sync actions for authentication, and an
HoC, requiresLogin.  If the HoC sees that we are still waiting for auth,
it displays a "Logging in" message, and only redirects when it knows we
have failed to log in.

**Don't merge until corresponding curric changes are written**